### PR TITLE
moving variables to separate files

### DIFF
--- a/.config/shell/env/00-def-progs
+++ b/.config/shell/env/00-def-progs
@@ -1,0 +1,8 @@
+# default programs
+export EDITOR="nvim"
+export TERM="st"
+export TERMINAL="st"
+export MUSPLAYER="termusic"
+export BROWSER="firefox"
+export BROWSER2="librewolf"
+# export DISPLAY=:0 # useful for some scripts

--- a/.config/shell/env/01-xdg
+++ b/.config/shell/env/01-xdg
@@ -1,0 +1,4 @@
+# follow XDG base dir specification
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_CACHE_HOME="$HOME/.cache"

--- a/.config/shell/env/03-zdot
+++ b/.config/shell/env/03-zdot
@@ -1,0 +1,2 @@
+# bootstrap .zshrc to ~/.config/zsh/.zshrc, any other zsh config files can also reside here
+export ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/.config/shell/env/colors
+++ b/.config/shell/env/colors
@@ -1,0 +1,11 @@
+export MANPAGER="less -R --use-color -Dd+r -Du+b" # colored man pages
+
+# colored less + termcap vars
+export LESS="R --use-color -Dd+r -Du+b"
+export LESS_TERMCAP_mb="$(printf '%b' '[1;31m')"
+export LESS_TERMCAP_md="$(printf '%b' '[1;36m')"
+export LESS_TERMCAP_me="$(printf '%b' '[0m')"
+export LESS_TERMCAP_so="$(printf '%b' '[01;44;33m')"
+export LESS_TERMCAP_se="$(printf '%b' '[0m')"
+export LESS_TERMCAP_us="$(printf '%b' '[1;32m')"
+export LESS_TERMCAP_ue="$(printf '%b' '[0m')"

--- a/.config/shell/env/fzf
+++ b/.config/shell/env/fzf
@@ -1,0 +1,2 @@
+export FZF_DEFAULT_OPTS="--style minimal --color 16 --layout=reverse --height 30% --preview='bat -p --color=always {}'"
+export FZF_CTRL_R_OPTS="--style minimal --color 16 --info inline --no-sort --no-preview" # separate opts for history widget

--- a/.config/shell/env/hist
+++ b/.config/shell/env/hist
@@ -1,0 +1,3 @@
+# history files
+export LESSHISTFILE="$XDG_CACHE_HOME/less_history"
+export PYTHON_HISTORY="$XDG_DATA_HOME/python/history"

--- a/.config/shell/env/other
+++ b/.config/shell/env/other
@@ -1,0 +1,21 @@
+# moving other files and some other vars
+export XINITRC="$XDG_CONFIG_HOME/x11/xinitrc"
+export XPROFILE="$XDG_CONFIG_HOME/x11/xprofile"
+export XRESOURCES="$XDG_CONFIG_HOME/x11/xresources"
+export GTK2_RC_FILES="$XDG_CONFIG_HOME/gtk-2.0/gtkrc-2.0" # gtk 3 & 4 are XDG compliant
+export WGETRC="$XDG_CONFIG_HOME/wget/wgetrc"
+export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/pythonrc"
+export GNUPGHOME="$XDG_DATA_HOME/gnupg"
+export CARGO_HOME="$XDG_DATA_HOME/cargo"
+export GOPATH="$XDG_DATA_HOME/go"
+export GOBIN="$GOPATH/bin"
+export GOMODCACHE="$XDG_CACHE_HOME/go/mod"
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
+export GRADLE_USER_HOME="$XDG_DATA_HOME/gradle"
+export NUGET_PACKAGES="$XDG_CACHE_HOME/NuGetPackages"
+export _JAVA_OPTIONS=-Djava.util.prefs.userRoot="$XDG_CONFIG_HOME/java"
+export _JAVA_AWT_WM_NONREPARENTING=1
+export PARALLEL_HOME="$XDG_CONFIG_HOME/parallel"
+export FFMPEG_DATADIR="$XDG_CONFIG_HOME/ffmpeg"
+export WINEPREFIX="$XDG_DATA_HOME/wineprefixes/default"
+export DATE=$(date "+%A, %B %e  %_I:%M%P")

--- a/.config/shell/env/path
+++ b/.config/shell/env/path
@@ -1,0 +1,2 @@
+# add scripts to path
+export PATH="$XDG_CONFIG_HOME/scripts:$PATH"

--- a/.config/zsh/.zprofile
+++ b/.config/zsh/.zprofile
@@ -2,62 +2,11 @@
 # env vars to set on login, zsh settings in ~/config/zsh/.zshrc
 # add `export ZDOTDIR="$HOME/.config/zsh"` to /etc/zsh/zshenv in order to place this file at .config/zsh/.zprofile
 
-# default programs
-export EDITOR="nvim"
-export TERM="st"
-export TERMINAL="st"
-export MUSPLAYER="termusic"
-export BROWSER="firefox"
-export BROWSER2="librewolf"
-# export DISPLAY=:0 # useful for some scripts
+# sourcing all files from folder
+[ -e "$HOME/.config/shell/env" ] && [ -d "$HOME/.config/shell/env" ] && source <(cat "$HOME"/.config/shell/env/*)
 
-# follow XDG base dir specification
-export XDG_CONFIG_HOME="$HOME/.config"
-export XDG_DATA_HOME="$HOME/.local/share"
-export XDG_CACHE_HOME="$HOME/.cache"
+# sourcing individual files
+#[ -e "$HOME/.config/shell/env" ] && [ -d "$HOME/.config/shell/env" ] && source <(cat "$HOME"/.config/shell/env/{00-def-progs,01-xdg,03-zdot,path,other})
 
-# bootstrap .zshrc to ~/.config/zsh/.zshrc, any other zsh config files can also reside here
-export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
-
-# history files
-export LESSHISTFILE="$XDG_CACHE_HOME/less_history"
-export PYTHON_HISTORY="$XDG_DATA_HOME/python/history"
-
-# add scripts to path
-export PATH="$XDG_CONFIG_HOME/scripts:$PATH"
-
-# moving other files and some other vars
-export XINITRC="$XDG_CONFIG_HOME/x11/xinitrc"
-export XPROFILE="$XDG_CONFIG_HOME/x11/xprofile"
-export XRESOURCES="$XDG_CONFIG_HOME/x11/xresources"
-export GTK2_RC_FILES="$XDG_CONFIG_HOME/gtk-2.0/gtkrc-2.0" # gtk 3 & 4 are XDG compliant
-export WGETRC="$XDG_CONFIG_HOME/wget/wgetrc"
-export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/pythonrc"
-export GNUPGHOME="$XDG_DATA_HOME/gnupg"
-export CARGO_HOME="$XDG_DATA_HOME/cargo"
-export GOPATH="$XDG_DATA_HOME/go"
-export GOBIN="$GOPATH/bin"
-export GOMODCACHE="$XDG_CACHE_HOME/go/mod"
-export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
-export GRADLE_USER_HOME="$XDG_DATA_HOME/gradle"
-export NUGET_PACKAGES="$XDG_CACHE_HOME/NuGetPackages"
-export _JAVA_OPTIONS=-Djava.util.prefs.userRoot="$XDG_CONFIG_HOME/java"
-export _JAVA_AWT_WM_NONREPARENTING=1
-export PARALLEL_HOME="$XDG_CONFIG_HOME/parallel"
-export FFMPEG_DATADIR="$XDG_CONFIG_HOME/ffmpeg"
-export WINEPREFIX="$XDG_DATA_HOME/wineprefixes/default"
-export DATE=$(date "+%A, %B %e  %_I:%M%P")
-
-export FZF_DEFAULT_OPTS="--style minimal --color 16 --layout=reverse --height 30% --preview='bat -p --color=always {}'"
-export FZF_CTRL_R_OPTS="--style minimal --color 16 --info inline --no-sort --no-preview" # separate opts for history widget
-export MANPAGER="less -R --use-color -Dd+r -Du+b" # colored man pages
-
-# colored less + termcap vars
-export LESS="R --use-color -Dd+r -Du+b"
-export LESS_TERMCAP_mb="$(printf '%b' '[1;31m')"
-export LESS_TERMCAP_md="$(printf '%b' '[1;36m')"
-export LESS_TERMCAP_me="$(printf '%b' '[0m')"
-export LESS_TERMCAP_so="$(printf '%b' '[01;44;33m')"
-export LESS_TERMCAP_se="$(printf '%b' '[0m')"
-export LESS_TERMCAP_us="$(printf '%b' '[1;32m')"
-export LESS_TERMCAP_ue="$(printf '%b' '[0m')"
+# excluding individual files from sourcing
+#[ -e "$HOME/.config/shell/env" ] && [ -d "$HOME/.config/shell/env" ] && source <(find "$HOME"/.config/shell/env -type f -not -regex '.*/\(path\|01-xdg\|other\)$' | sort | xargs cat)


### PR DESCRIPTION
Hi from Ukraine!

Instead of storing environment variables in the `.zprofile` file, you can source them from the `.config/shell/env/` folder.
There, you can separate them into different files by category.

This allows you to source environment variables into bash to, for example.

**IMPORTANT**: P​lace the numeric prefix into file name like `01-` so that it is loaded first.

In `.zprofile` you can choose to source all files from folder, source individual files or exclude files from list